### PR TITLE
fixing alternatives from evidence prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ Since GALBA is a pipeline that calls several Bioinformatics tools, publication o
 
 -   If GALBA was executed with Miniprot, cite:
 
-    -   Li, H. (2022) “Protein-to-genome alignment with miniprot.” arXiv:2210.08052v1.
+    -   Li, H. (2023). Protein-to-genome alignment with miniprot. Bioinformatics, 39(1), btad014.
 
 -   If GALBA was executed with GenomeThreader, cite:
 
@@ -743,7 +743,7 @@ Footnotes
 References
 ==========
 
-<b id="f1">[R1]</b> Li, H. (2022) “Protein-to-genome alignment with miniprot.” arXiv:2210.08052v1.[↩](#a1)
+<b id="f1">[R1]</b> Li, H. (2023). Protein-to-genome alignment with miniprot. Bioinformatics, 39(1), btad014.[↩](#a1)
 
 <b id="f2">[R2]</b> Gremme, G. 2013. “Computational Gene Structure Prediction.” PhD thesis, Universität Hamburg.[↩](#a2)
 

--- a/scripts/galba.pl
+++ b/scripts/galba.pl
@@ -5030,10 +5030,8 @@ sub augustus {
               ."'hintsfile' : '$otherfilesDir/hintsfile.gff', "
               ."'extrinsicCfgFile' : '$extrinsicCfgFile', "
               ."'outfile' : '$otherfilesDir/augustus.hints.gff'";
-    if (defined($alt_off)){
-        if ( not($alt_off =~ m/alt_off/) ) {
-            print AUGH ", 'alternatives-from-evidence' : $alternatives_from_evidence";
-        }
+    if (not(defined($alt_off))){
+        print AUGH ", 'alternatives-from-evidence' : $alternatives_from_evidence";
     }
     if ( defined($optCfgFile) ) {
         print AUGH ", 'optCfgFile' : '$optCfgFile'";


### PR DESCRIPTION
I had disabled alternatives from evidence for training gene filtering but there was a bug in the actual augustus run, where alternatives from evidence were now not allowed, anymore. Fixed.