### PR TITLE
fix:  fix `$DIAMOND_PATH` uninitialised error with `--skipAllTraining` option

### DIFF
--- a/scripts/galba.pl
+++ b/scripts/galba.pl
@@ -544,7 +544,10 @@ set_AUGUSTUS_BIN_PATH(); # determine bin and scripts relative to config path
 set_AUGUSTUS_SCRIPTS_PATH();
 fix_AUGUSTUS_CONFIG_PATH(); # if not writable, set to ~/.augustus
 set_PYTHON3_PATH();
-set_DIAMOND_PATH();
+
+if (not ($skipAllTraining && $disable_diamond_filter)){
+    set_DIAMOND_PATH();
+}
 
 if(@prot_seq_files && $prg eq "miniprot"){
     set_MINIPROT_PATH();

--- a/scripts/galba.pl
+++ b/scripts/galba.pl
@@ -544,10 +544,7 @@ set_AUGUSTUS_BIN_PATH(); # determine bin and scripts relative to config path
 set_AUGUSTUS_SCRIPTS_PATH();
 fix_AUGUSTUS_CONFIG_PATH(); # if not writable, set to ~/.augustus
 set_PYTHON3_PATH();
-
-if (not ($skipAllTraining)){
-    set_DIAMOND_PATH();
-}
+set_DIAMOND_PATH();
 
 if(@prot_seq_files && $prg eq "miniprot"){
     set_MINIPROT_PATH();


### PR DESCRIPTION
Running `galba.pl` with the `--skipAllTraining` flag causes the $DIAMOND_PATH variable to be uninitialised, which leads to a failure in the `filter_gtf_by_diamond_against_ref.py` script. 

This PR resolves the issue, and my test run has completed successfully.

Below are the details to replicate the error
Command used:
```console
galba.pl  --skipAllTraining --workingdir=/path/to/output \
    --genome /path/to/genome.fa --prot_seq=/path/to/proteins.fa \
    --gff3 --verbosity=4 --threads 8 --species=genus_species \
    --AUGUSTUS_CONFIG_PATH /path/to/config
```

Error from STDERR
```console
Use of uninitialized value $DIAMOND_PATH in concatenation (.) or string at /opt/GALBA/scripts/galba.pl line 6186.
ERROR in file /opt/GALBA/scripts/galba.pl at line 6191
```

Error from `errors/filter_gtf_by_diamond_against_ref.stderr`
```console
$ cat errors/filter_gtf_by_diamond_against_ref.stderr
usage: filter_gtf_by_diamond_against_ref.py [-h] -r REF_PROTS [-g GTF]
                                            [-a PRED_PROTS] -o OUT_GTF
                                            [-t THREADS] -d DIAMOND_DIR
filter_gtf_by_diamond_against_ref.py: error: argument -d/--diamond_dir: expected one argument
```